### PR TITLE
refactor: Unify tool context interfaces

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -21,7 +21,7 @@ export class Handlers {
   private projectName: string;
   private cosenseOptions: { sid?: string };
   private pageResources: Resources<PageResource> = new Resources();
-  private tools: Tool[];
+  private tools: Tool<unknown>[];
 
   private constructor(config: Config) {
     this.projectName = config.projectName;
@@ -75,33 +75,11 @@ export class Handlers {
       throw new Error(`Unknown tool: ${request.params.name}`);
     }
 
-    const context = this.createToolContext(tool);
-    return await tool.execute(request.params.arguments ?? {}, context);
-  }
+    const context = {
+      projectName: this.projectName,
+      cosenseOptions: this.cosenseOptions,
+    };
 
-  private createToolContext<TContext>(tool: Tool<TContext>): TContext {
-    switch (tool.name) {
-      case getPageTool.name:
-        return {
-          projectName: this.projectName,
-          cosenseOptions: this.cosenseOptions,
-        } as TContext;
-      case listPagesTool.name:
-        return {
-          pageResources: this.pageResources,
-        } as TContext;
-      case searchPagesTool.name:
-        return {
-          projectName: this.projectName,
-          cosenseOptions: this.cosenseOptions,
-        } as TContext;
-      case insertLinesTool.name:
-        return {
-          projectName: this.projectName,
-          cosenseOptions: this.cosenseOptions,
-        } as TContext;
-      default:
-        throw new Error(`Unknown tool: ${tool.name}`);
-    }
+    return await tool.execute(request.params.arguments ?? {}, context);
   }
 }

--- a/src/tools/getPageTool.ts
+++ b/src/tools/getPageTool.ts
@@ -1,13 +1,12 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { getPage, pageToText } from '../cosense.js';
-import type { Tool } from './types.js';
+import type { Tool, ToolContext } from './types.js';
 
-export interface GetPageContext {
-  projectName: string;
-  cosenseOptions: { sid?: string };
-}
+type GetPageArgs = {
+  pageTitle: string;
+};
 
-export const getPageTool: Tool<GetPageContext, { pageTitle: string }> = {
+export const getPageTool: Tool<GetPageArgs> = {
   name: 'get_page',
   description: 'Get a page with the specified title from the Cosense project.',
   inputSchema: {
@@ -21,8 +20,8 @@ export const getPageTool: Tool<GetPageContext, { pageTitle: string }> = {
     required: ['pageTitle'],
   },
   async execute(
-    { pageTitle }: { pageTitle: string },
-    { projectName, cosenseOptions }: GetPageContext
+    { pageTitle }: GetPageArgs,
+    { projectName, cosenseOptions }: ToolContext
   ): Promise<CallToolResult> {
     const page = await getPage(projectName, pageTitle, cosenseOptions);
     return {

--- a/src/tools/insertLinesTool.ts
+++ b/src/tools/insertLinesTool.ts
@@ -1,20 +1,15 @@
 import { patch } from '@cosense/std/websocket';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { unwrapErr } from 'option-t/plain_result';
-import type { Tool } from './types.js';
+import type { Tool, ToolContext } from './types.js';
 
-export interface InsertLinesContext {
-  projectName: string;
-  cosenseOptions: { sid?: string };
-}
-
-interface InsertLinesArgs {
+type InsertLinesArgs = {
   pageTitle: string;
   targetLineText: string;
   text: string;
-}
+};
 
-export const insertLinesTool: Tool<InsertLinesContext, InsertLinesArgs> = {
+export const insertLinesTool: Tool<InsertLinesArgs> = {
   name: 'insert_lines',
   description:
     'Insert lines after the specified target line in a Cosense page. If the target line is not found, append to the end of the page.',
@@ -40,7 +35,7 @@ export const insertLinesTool: Tool<InsertLinesContext, InsertLinesArgs> = {
   },
   async execute(
     { pageTitle, targetLineText, text }: InsertLinesArgs,
-    { projectName, cosenseOptions }: InsertLinesContext
+    { projectName, cosenseOptions }: ToolContext
   ): Promise<CallToolResult> {
     const result = await patch(
       projectName,

--- a/src/tools/listPagesTool.ts
+++ b/src/tools/listPagesTool.ts
@@ -1,31 +1,30 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { PageResource, Resources } from '../resource.js';
-import type { Tool } from './types.js';
+import { listPages } from '../cosense.js';
+import { PageResource } from '../resource.js';
+import type { Tool, ToolContext } from './types.js';
 
-export interface ListPagesContext {
-  pageResources: Resources<PageResource>;
-}
+type ListPagesArgs = Record<string, never>;
 
-export const listPagesTool: Tool<ListPagesContext> = {
+export const listPagesTool: Tool<ListPagesArgs> = {
   name: 'list_pages',
-  description: 'List Cosense pages in the resources.',
+  description: 'List Cosense pages in the project.',
   inputSchema: {
     type: 'object' as const,
     properties: {},
     required: [],
   },
   async execute(
-    _args: Record<string, unknown>,
-    { pageResources }: ListPagesContext
+    _args: ListPagesArgs,
+    { projectName, cosenseOptions }: ToolContext
   ): Promise<CallToolResult> {
+    const pageList = await listPages(projectName, cosenseOptions);
+    const pages = pageList.pages.map((page) => new PageResource(page));
+
     return {
       content: [
         {
           type: 'text',
-          text: pageResources
-            .getAll()
-            .map((r) => r.description)
-            .join('\n-----\n'),
+          text: pages.map((r) => r.description).join('\n-----\n'),
         },
       ],
     };

--- a/src/tools/searchPagesTool.ts
+++ b/src/tools/searchPagesTool.ts
@@ -1,14 +1,13 @@
 import type { FoundPage, SearchResult } from '@cosense/types/rest';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { searchForPages } from '../cosense.js';
-import type { Tool } from './types.js';
+import type { Tool, ToolContext } from './types.js';
 
-export interface SearchPagesContext {
-  projectName: string;
-  cosenseOptions: { sid?: string };
-}
+type SearchPagesArgs = {
+  query: string;
+};
 
-export const searchPagesTool: Tool<SearchPagesContext, { query: string }> = {
+export const searchPagesTool: Tool<SearchPagesArgs> = {
   name: 'search_pages',
   description:
     'Search for pages containing the specified query string in the Cosense project.',
@@ -26,8 +25,8 @@ export const searchPagesTool: Tool<SearchPagesContext, { query: string }> = {
 };
 
 async function execute(
-  { query }: { query: string },
-  { projectName, cosenseOptions }: SearchPagesContext
+  { query }: SearchPagesArgs,
+  { projectName, cosenseOptions }: ToolContext
 ): Promise<CallToolResult> {
   const searchResult = await searchForPages(query, projectName, cosenseOptions);
   return {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -3,6 +3,11 @@ import type {
   Tool as _Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 
-export interface Tool<TContext = unknown, TArgs = unknown> extends _Tool {
-  execute(args: TArgs, context: TContext): Promise<CallToolResult>;
+export interface ToolContext {
+  projectName: string;
+  cosenseOptions: { sid?: string };
+}
+
+export interface Tool<TArgs> extends _Tool {
+  execute(args: TArgs, context: ToolContext): Promise<CallToolResult>;
 }


### PR DESCRIPTION
## Summary
Unifies tool context handling by introducing a single `ToolContext` interface, eliminating code duplication and simplifying the architecture.

## Changes
- Added unified `ToolContext` interface
- Removed tool-specific context interfaces (`GetPageContext`, `InsertLinesContext`, etc.)
- Simplified `Tool` interface to single type parameter
- Removed complex `createToolContext` switch-case logic
- Updated `listPagesTool` to use API calls instead of resources

## Benefits
- Eliminates code duplication
- Improves maintainability
- Consistent type definitions across all tools

## Testing
- [x] TypeScript build passes
- [x] No breaking changes

**Files changed:** `handlers.ts`, `types.ts`, and all tool files.