### PR TITLE
Fix JSON parse errors from MCP inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "start": "tsx src/index.ts",
     "start:dev": "tsx watch src/index.ts",
-    "inspect": "npx @modelcontextprotocol/inspector npm run start"
+    "inspect": "npx @modelcontextprotocol/inspector -- tsx src/index.ts"
   },
   "dependencies": {
     "@cosense/std": "npm:@jsr/cosense__std@^0.29.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { registerSearchPagesTool } from './tools/searchPagesTool.js';
 // Import resources
 import { registerPageResources } from './resources/pageResources.js';
 
-dotenv.config();
+dotenv.config({ quiet: true });
 
 try {
   const config = getConfig();


### PR DESCRIPTION
Fix #17

- dotenvのログがstdoutを汚染していたので`dotenv.config({ quiet: true })`として抑制
- inspectorに渡される`npm run start`の起動時の出力がstdoutを汚染していたので、中身の`tsx`コマンドを直接渡すことで回避
