### PR TITLE
Await `registerPageResources` before connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,11 @@ try {
   registerListPagesTool(server, config);
   registerSearchPagesTool(server, config);
 
-  // Start page resource registration asynchronously
-  const resourcesPromise = registerPageResources(server, config);
+  // Register page resources
+  await registerPageResources(server, config);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-
-  // Now wait for resource registration to complete
-  await resourcesPromise;
 } catch (error) {
   logger.error('Server error:', error);
   process.exit(1);


### PR DESCRIPTION
Fix #18 

`server.connect(transport)` で接続した後に `await resourcesPromise` でリソースを追加 (`server.resource(...)`) していたが、接続後はcapabilitiesの変更が禁止されているためSDKが例外を投げていた。
一旦awaitを接続前に行うことで回避した。（registerPageResourcesを同期関数にすべき？）

#### 将来的な変更案
- ページ数を制限してパフォーマンスや表示の問題に対処する
- Resource Template (?) を使って後から動的に追加できるようにする
- 不要ならResourceのサポートをやめる