### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,14 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
   quality-checks:
     name: Code Quality Checks
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
 
     steps:
       - name: Checkout code
@@ -22,10 +20,10 @@ jobs:
         with:
           version: latest
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
- mainブランチへのpush/PRでのみ実行
- Node.jsの複数バージョンではなく最新版(v22)のみでチェック